### PR TITLE
Update Readme

### DIFF
--- a/10.一键生成个人微信朋友圈数据电子书/README.md
+++ b/10.一键生成个人微信朋友圈数据电子书/README.md
@@ -201,6 +201,8 @@ while(True):
 
 其中，`document.getElementsByClassName("lazy-img")[0]`指的是`document.getElementsByClassName("lazy-img")`的第一个元素，`scrollIntoView()`指的是滚动到该元素的位置
 
+有时候测试比较长的朋友圈页面，最后几页的图片仍然会出现处于加载状态的情况。
+这时候可以在打印代码前增加一个input()函数暂停，用手工翻页的方法确保全部页面都加载成功，最后再输入任意字符打印。
 
 #### 打印电子书
 


### PR DESCRIPTION
发现一个bug，有时候最后几页的图片仍然无法自动加载完成。
建议在打印前增加一个input（）函数暂停，手工检测并滚动加载全部图片。